### PR TITLE
Add liftMaybeM to Control.Eff.Exception

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 }:
 mkDerivation {
   pname = "extensible-effects";
-  version = "1.11.0.3";
+  version = "1.11.1.0";
   src = ./.;
   buildDepends = [
     base transformers transformers-base type-aligned void

--- a/extensible-effects.cabal
+++ b/extensible-effects.cabal
@@ -6,7 +6,7 @@ name:                extensible-effects
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             1.11.0.4
+version:             1.11.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            An Alternative to Monad Transformers

--- a/src/Control/Eff/Exception.hs
+++ b/src/Control/Eff/Exception.hs
@@ -108,7 +108,7 @@ liftMaybe = maybe die return
 {-# INLINE liftMaybe #-}
 
 -- | `liftMaybe` in a lifted Monad
-liftMaybeM :: (Typeable m, Member Fail r, SetMember Lift (Lift m) r)
+liftMaybeM :: (Typeable1 m, Member Fail r, SetMember Lift (Lift m) r)
            => m (Maybe a)
            -> Eff r a
 liftMaybeM m = lift m >>= liftMaybe

--- a/src/Control/Eff/Exception.hs
+++ b/src/Control/Eff/Exception.hs
@@ -17,6 +17,7 @@ module Control.Eff.Exception( Exc (..)
                             , liftEither
                             , liftEitherM
                             , liftMaybe
+                            , liftMaybeM
                             , ignoreFail
                             ) where
 
@@ -105,6 +106,13 @@ liftEitherM m = lift m >>= liftEither
 liftMaybe :: Member Fail r => Maybe a -> Eff r a
 liftMaybe = maybe die return
 {-# INLINE liftMaybe #-}
+
+-- | `liftMaybe` in a lifted Monad
+liftMaybeM :: (Typeable m, Member Fail r, SetMember Lift (Lift m) r)
+           => m (Maybe a)
+           -> Eff r a
+liftMaybeM m = lift m >>= liftMaybe
+{-# INLINE liftMaybeM #-}
 
 -- | Ignores a failure event. Since the event can fail, you cannot inspect its
 --   return type, because it has none on failure. To inspect it, use 'runFail'.


### PR DESCRIPTION
I think `liftMaybeM` should be defined in Control.Eff.Exception,
because `liftEitherM` is defined in Control.Eff.Exception,
and I want to use `liftMaybeM` :dog2: