### PR TITLE
Add member list operator

### DIFF
--- a/src/Control/Eff/Example.hs
+++ b/src/Control/Eff/Example.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Werror #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeOperators, GADTs, DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Safe #-}
@@ -25,10 +26,9 @@ runErrBig = runError
 -- }}}
 
 -- | Multiple Reader effects
-sum2 :: [ Reader Int
-        , Reader Float
-        ] ::> r
-     => Eff r Float
+sum2 :: ([ Reader Int
+         , Reader Float
+         ] ::> r) => Eff r Float
 sum2 = do
   v1 <- ask
   v2 <- ask

--- a/src/Control/Eff/Example.hs
+++ b/src/Control/Eff/Example.hs
@@ -25,8 +25,9 @@ runErrBig = runError
 -- }}}
 
 -- | Multiple Reader effects
-sum2 :: Member (Reader Int) r
-     => Member (Reader Float) r
+sum2 :: [ Reader Int
+        , Reader Float
+        ] ::> r
      => Eff r Float
 sum2 = do
   v1 <- ask
@@ -46,7 +47,10 @@ sumAll :: (Num a, Member (State a) e)
 sumAll = mapM_ (modify . (+))
 
 -- | Write a list of numbers and add them to the current state.
-writeAndAdd :: (Member (Writer a) e, Member (State a) e, Num a)
+writeAndAdd :: ( [ Writer a
+                 , State a
+                 ] ::> e
+               , Num a)
             => [a]
             -> Eff e ()
 writeAndAdd l = do

--- a/src/Control/Eff/Example.hs
+++ b/src/Control/Eff/Example.hs
@@ -28,7 +28,7 @@ runErrBig = runError
 -- | Multiple Reader effects
 sum2 :: ([ Reader Int
          , Reader Float
-         ] ::> r) => Eff r Float
+         ] <:: r) => Eff r Float
 sum2 = do
   v1 <- ask
   v2 <- ask
@@ -49,7 +49,7 @@ sumAll = mapM_ (modify . (+))
 -- | Write a list of numbers and add them to the current state.
 writeAndAdd :: ( [ Writer a
                  , State a
-                 ] ::> e
+                 ] <:: e
                , Num a)
             => [a]
             -> Eff e ()

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -1,18 +1,22 @@
 {-# OPTIONS_HADDOCK show-extensions #-}
+{-# OPTIONS_GHC -Wwarn #-}
 
 {-# LANGUAGE CPP #-}
 
-{-# LANGUAGE TypeFamilies, TypeOperators #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE DataKinds, PolyKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
 {-# LANGUAGE Trustworthy #-}
-{-# OPTIONS_GHC -Wwarn #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 #if __GLASGOW_HASKELL__ < 710 || FORCE_OU51
 {-# LANGUAGE OverlappingInstances #-}
-#else
 #endif
 
 -- Only for SetMember below, when emulating Monad Transformers

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -137,8 +137,18 @@ instance {-# INCOHERENT #-}  (FindElem t r) => Member t r where
   prj = prj' (unP $ (elemNo :: P t r))
 #endif
 
--- | The operator for reducing boilerplate.
--- @[c1, c2] ::> r@ is equivalent to @(Member c1 r, Member c2 r)@.
+-- | A useful operator for reducing boilerplate.
+--
+-- @
+-- f :: [Reader Int, Writer String] ::> r
+--   => a -> Eff r b
+-- @
+-- is equal to
+--
+-- @
+-- f :: (Member (Reader Int) r, Member (Writer String) r)
+--   => a -> Eff r b
+-- @
 type family (::>) (ms :: [* -> *]) r where
   (::>) '[] r = (() :: Constraint)
   (::>) (m : ms) r = (Member m r, (::>) ms r)

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -137,6 +137,8 @@ instance {-# INCOHERENT #-}  (FindElem t r) => Member t r where
   prj = prj' (unP $ (elemNo :: P t r))
 #endif
 
+-- | The operator for reducing boilerplate.
+-- @[c1, c2] ::> r@ is equivalent to @(Member c1 r, Member c2 r)@.
 type family (::>) (ms :: [* -> *]) r where
   (::>) '[] r = (() :: Constraint)
   (::>) (m : ms) r = (Member m r, (::>) ms r)

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -61,7 +61,7 @@ module Data.OpenUnion ( Union
                       , decomp
                       , Member
                       , SetMember
-                      , (::>)
+                      , type(<::)
                       , weaken
                       ) where
 
@@ -151,9 +151,9 @@ instance {-# INCOHERENT #-}  (FindElem t r) => Member t r where
 -- f :: (Member (Reader Int) r, Member (Writer String) r)
 --   => a -> Eff r b
 -- @
-type family (::>) (ms :: [* -> *]) r where
-  (::>) '[] r = (() :: Constraint)
-  (::>) (m ': ms) r = (Member m r, (::>) ms r)
+type family (<::) (ms :: [* -> *]) r where
+  (<::) '[] r = (() :: Constraint)
+  (<::) (m ': ms) r = (Member m r, (<::) ms r)
 
 {-# INLINE [2] decomp #-}
 decomp :: Union (t ': r) v -> Either (Union r v) (t v)

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -65,11 +65,13 @@ module Data.OpenUnion ( Union
                       , weaken
                       ) where
 
-import Data.Kind (Constraint)
 import Unsafe.Coerce(unsafeCoerce)
 
 #if __GLASGOW_HASKELL__ > 800
+import Data.Kind (Constraint)
 import GHC.TypeLits
+#else
+import GHC.Exts (Constraint)
 #endif
 
 -- | The data constructors of Union are not exported
@@ -151,7 +153,7 @@ instance {-# INCOHERENT #-}  (FindElem t r) => Member t r where
 -- @
 type family (::>) (ms :: [* -> *]) r where
   (::>) '[] r = (() :: Constraint)
-  (::>) (m : ms) r = (Member m r, (::>) ms r)
+  (::>) (m ': ms) r = (Member m r, (::>) ms r)
 
 {-# INLINE [2] decomp #-}
 decomp :: Union (t ': r) v -> Either (Union r v) (t v)

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -55,11 +55,19 @@
 -- type t in the list r as the TRep. (We will need UnsafeCoerce then).
 --
 -- The interface is the same as of other OpenUnion*.hs
-module Data.OpenUnion (Union, inj, prj, decomp,
-                   Member, SetMember, weaken
-                  ) where
+module Data.OpenUnion ( Union
+                      , inj
+                      , prj
+                      , decomp
+                      , Member
+                      , SetMember
+                      , (::>)
+                      , weaken
+                      ) where
 
+import Data.Kind (Constraint)
 import Unsafe.Coerce(unsafeCoerce)
+
 #if __GLASGOW_HASKELL__ > 800
 import GHC.TypeLits
 #endif
@@ -128,6 +136,10 @@ instance {-# INCOHERENT #-}  (FindElem t r) => Member t r where
   inj = inj' (unP $ (elemNo :: P t r))
   prj = prj' (unP $ (elemNo :: P t r))
 #endif
+
+type family (::>) (ms :: [* -> *]) r where
+  (::>) '[] r = (() :: Constraint)
+  (::>) (m : ms) r = (Member m r, (::>) ms r)
 
 {-# INLINE [2] decomp #-}
 decomp :: Union (t ': r) v -> Either (Union r v) (t v)


### PR DESCRIPTION
This PR add (::>) type level operator to reduce boilerplate in function constraints.

For example, [E1, E2] ::> r is expanded to (Member E1 r, Member E2 r).

As always, the name could be better, so I'm open to suggestions in this case.