### PR TITLE
Add throwError' to Exception effect that has return type ()

### DIFF
--- a/src/Control/Eff/Exception.hs
+++ b/src/Control/Eff/Exception.hs
@@ -10,6 +10,7 @@
 module Control.Eff.Exception ( Exc (..)
                             , Fail
                             , throwError
+                            , throwError'
                             , die
                             , runError
                             , runFail
@@ -52,6 +53,11 @@ type Fail = Exc ()
 throwError :: (Member (Exc e) r) => e -> Eff r a
 throwError e = send (Exc e)
 {-# INLINE throwError #-}
+
+-- | Throw an exception in an effectful computation. The type is unit, which suppresses the ghc-mod warning "A do-notation statement discarded a result of type"
+throwError' :: (Member (Exc e) r) => e -> Eff r ()
+throwError' = throwError
+{-# INLINE throwError' #-}
 
 -- | Makes an effect fail, preventing future effects from happening.
 die :: Member Fail r => Eff r a

--- a/src/Control/Eff/Exception.hs
+++ b/src/Control/Eff/Exception.hs
@@ -10,7 +10,7 @@
 module Control.Eff.Exception ( Exc (..)
                             , Fail
                             , throwError
-                            , throwError'
+                            , throwError_
                             , die
                             , runError
                             , runFail
@@ -54,10 +54,12 @@ throwError :: (Member (Exc e) r) => e -> Eff r a
 throwError e = send (Exc e)
 {-# INLINE throwError #-}
 
--- | Throw an exception in an effectful computation. The type is unit, which suppresses the ghc-mod warning "A do-notation statement discarded a result of type"
-throwError' :: (Member (Exc e) r) => e -> Eff r ()
-throwError' = throwError
-{-# INLINE throwError' #-}
+-- | Throw an exception in an effectful computation. The type is unit, 
+--   which suppresses the ghc-mod warning "A do-notation statement 
+--   discarded a result of type"
+throwError_ :: (Member (Exc e) r) => e -> Eff r ()
+throwError_ = throwError
+{-# INLINE throwError_ #-}
 
 -- | Makes an effect fail, preventing future effects from happening.
 die :: Member Fail r => Eff r a


### PR DESCRIPTION
in Control.Eff.Exception the `throwError` function has result type `Eff r a`, which results in a ghc-mod warning "A do-notation statement discarded a result of type" when `throwError someError` is used in the middle of a `do`-block. Ghc also reports a warning `[-Wunused-do-bind]` 

minimal Example: 
```haskell
do
    throwError someError -- warning here
    return ()
```

The warnings are muted by rephrasing to `_ <- throwError someError`, which is inconvenient and slightly misleading. 

My pull reqest adds a function `throwError'`, which is the same as `throwError` with the result-type set to `()`. This also mutes the warnings.
