### PR TITLE
Revert "debug: travis: disable Alternative and MonadPlus for ghc 7.8"

### DIFF
--- a/extensible-effects.cabal
+++ b/extensible-effects.cabal
@@ -6,7 +6,7 @@ name:                extensible-effects
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             2.6.0.3
+version:             2.6.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            An Alternative to Monad Transformers

--- a/src/Control/Eff/Choose.hs
+++ b/src/Control/Eff/Choose.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE CPP #-}
 -- The following is needed to define MonadPlus instance. It is decidable
 -- (there is no recursion!), but GHC cannot see that.
 {-# LANGUAGE UndecidableInstances #-}
@@ -21,9 +20,7 @@ module Control.Eff.Choose ( Choose (..)
 
 import Control.Eff.Internal
 import Data.OpenUnion
-#if __GLASGOW_HASKELL__ > 708
 import Control.Applicative
-#endif
 import Control.Monad
 import Control.Monad.Base
 import Control.Monad.Trans.Control
@@ -61,7 +58,6 @@ mzero' = choose []
 mplus' :: Member Choose r => Eff r a -> Eff r a -> Eff r a
 mplus' m1 m2 = join $ choose [m1,m2]
 
-#if __GLASGOW_HASKELL__ > 708
 -- | MonadPlus-like operators are expressible via choose
 instance Member Choose r => Alternative (Eff r) where
   empty = mzero'
@@ -70,7 +66,6 @@ instance Member Choose r => Alternative (Eff r) where
 instance Member Choose r => MonadPlus (Eff r) where
   mzero = empty
   mplus = (<|>)
-#endif
 
 -- | Run a nondeterministic effect, returning all values.
 makeChoice :: forall a r. Eff (Choose ': r) a -> Eff r [a]


### PR DESCRIPTION
This reverts commit d1c99374e33ac4ae443a034eccf55911ba774997.

Resolves #75.