### PR TITLE
MonadIO instance

### DIFF
--- a/extensible-effects.cabal
+++ b/extensible-effects.cabal
@@ -137,6 +137,9 @@ library
                ,       transformers-base == 0.4.*
                        -- For MonadBaseControl
                ,       monad-control >= 1.0 && < 1.1
+  if impl(ghc < 8.0)
+                       -- For MonadIO
+     build-depends:    transformers
 
   -- Directories containing source files.
   hs-source-dirs:      src

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -167,7 +167,10 @@ instance (MonadBase b m, SetMember Lift (Lift m) r) => MonadBase b (Eff r) where
 instance (MonadBase m m)  => MonadBaseControl m (Eff '[Lift m]) where
     type StM (Eff '[Lift m]) a = a
     liftBaseWith f = lift (f runLift)
+    {-# INLINE liftBaseWith #-}
     restoreM = return
+    {-# INLINE restoreM #-}
+
 
 -- | Send a request and wait for a reply (resulting in an effectful
 -- computation).

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -31,6 +31,7 @@ import Control.Applicative
 import qualified Control.Arrow as A
 import qualified Control.Category as C
 import Control.Monad.Base (MonadBase(..))
+import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Control (MonadBaseControl(..))
 import safe Data.OpenUnion
 import safe Data.FTCQueue
@@ -171,6 +172,9 @@ instance (MonadBase m m)  => MonadBaseControl m (Eff '[Lift m]) where
     restoreM = return
     {-# INLINE restoreM #-}
 
+instance (MonadIO m, SetMember Lift (Lift m) r) => MonadIO (Eff r) where
+    liftIO = lift . liftIO
+    {-# INLINE liftIO #-}
 
 -- | Send a request and wait for a reply (resulting in an effectful
 -- computation).


### PR DESCRIPTION
This adds somehow forgotten MonadIO instance for Lifted. Also some INLINE pragmas thrown in, though GHC should inline those functions in most cases anyway.