### PR TITLE
Addition to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,34 @@ possible to use the type operator `<::` and write
 
 ## Integration with IO
 
-*work in progress*
+`IO` as well as any other monad can be used as a base type for `Lift` effect.
+There may be at most one instance of `Lift` effect in the effects list, and it
+must be handled the last. `Control.Eff.Lift` exports `runLift` handler and
+`lift` function, that provides an ability to run arbitrary monadic actions.
+Also, there are convenient type aliases, that allow for shorter type constraints.
+
+```haskell
+f :: IO ()
+f = runLift $ do printHello
+                 printWorld
+
+-- These two functions' types are equivalent.
+
+printHello :: SetMember Lift (Lift IO) r => Eff r ()
+printHello = lift (putStr "Hello")
+
+printWorld :: Lifted IO r => Eff r ()
+printWorld = lift (putStrLn " world!")
+```
+
+Note that, since `Lift` is a terminal effect, you do not need to use `run` to
+extract pure value. Instead, `runLift` returns a value wrapped in whatever monad
+you chose to use.
+
+In addition, `Lift` effect provides `MonadBase`, `MonadBaseControl`, and `MonadIO`
+instances, that may be useful, especially with packages like [lifted-base](http://hackage.haskell.org/package/lifted-base),
+[lifted-async](http://hackage.haskell.org/package/lifted-async), and other
+code that uses those typeclasses.
 
 ## Integration with Monad Transformers
 

--- a/extensible-effects.cabal
+++ b/extensible-effects.cabal
@@ -139,7 +139,7 @@ library
                ,       monad-control >= 1.0 && < 1.1
   if impl(ghc < 8.0)
                        -- For MonadIO
-     build-depends:    transformers
+     build-depends:    transformers >= 0.2.0.0
 
   -- Directories containing source files.
   hs-source-dirs:      src


### PR DESCRIPTION
This also adds a lower bound on transformers dependency. MonadIO class appeared only in transformers-0.2.0.0. This is purely cosmetic, as I very much doubt anybody will use older versions of that package.