### PR TITLE
Friendly api exports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     - libgmp-dev
 
 env:
-- GHC="8.4.1"
+- GHC="8.4.2"
 - GHC="8.2.2"
 - GHC="8.0.2"
 - GHC="7.10.3"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GHCS = 7.8.4 7.10.3 8.0.2 8.2.2 8.4.1
+GHCS = 7.8.4 7.10.3 8.0.2 8.2.2 8.4.2
 
 # default ghc-version for targets, can be overwritten by make-
 GHC = 8.2.2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 *Implement effectful computations in a modular way!*
 
-The main and only monad is built upon `Eff` from `Control.Eff`.
+The main monad of this package is `Eff` from `Control.Eff`.
 `Eff r a` is parameterized by the effect-list `r` and the monadic-result type
 `a` similar to other monads.
 It is the intention that all other monadic computations can be replaced by the

--- a/extensible-effects.cabal
+++ b/extensible-effects.cabal
@@ -85,6 +85,7 @@ library
                        Control.Eff.Writer.Strict
                        Data.OpenUnion
                        Control.Eff.QuickStart
+                       Control.Eff.ImplementYourOwnEffect
 
   -- Modules included in this library but not exported.
   other-modules:       Control.Eff.Internal

--- a/extensible-effects.cabal
+++ b/extensible-effects.cabal
@@ -85,7 +85,7 @@ library
                        Control.Eff.Writer.Strict
                        Data.OpenUnion
                        Control.Eff.QuickStart
-                       Control.Eff.ImplementYourOwnEffect
+                       Control.Eff.Extend
 
   -- Modules included in this library but not exported.
   other-modules:       Control.Eff.Internal

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -1,8 +1,13 @@
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
 
+-- | The main entry-point of this library.
+--
+-- This module provides the @Eff@ monad - the base monad for all effectful
+-- computation.
+--
+
 module Control.Eff
   ( -- * Effect base-type
-    -- | The the monad that contains all effects --TODO: comment
     Internal.run
   , Internal.Eff
     -- * Effect list

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -1,11 +1,4 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExplicitNamespaces #-}
-
-#if __GLASGOW_HASKELL__ < 800
-{-# OPTIONS_GHC -fno-warn-duplicate-exports #-}
-#else
-{-# OPTIONS_GHC -Wno-duplicate-exports #-}
-#endif
 
 -- | A monadic library for implementing effectful computation in a modular way.
 --
@@ -32,11 +25,9 @@ module Control.Eff
   , Internal.Eff
     -- * Effect list
   , OpenUnion.Member
+  , OpenUnion.SetMember
   , type(<::)
-    -- Rest (not included in documentation somehow)
-  , module Internal
-  , module OpenUnion
   ) where
 
-import Control.Eff.Internal as Internal hiding (Lift(..), lift, runLift)
+import Control.Eff.Internal as Internal
 import Data.OpenUnion as OpenUnion

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -4,18 +4,19 @@
 --
 -- This module provides the @Eff@ monad - the base type for all effectful
 -- computation.
--- The @Member@ typeclass is the main interface for describing the .
+-- The @Member@ typeclass is the main interface for describing which effects
+-- are necessary for a given function.
 --
 -- Consult the @Control.Eff.QuickStart@ module and the readme for gentle
 -- introductions.
 --
 -- To use extensible effects effectively some language extensions are
--- necessary/suggested.
+-- necessary/recommended.
 --
 -- @
--- {-# LANGUAGE ScopedTypeVariables #-}
--- {-# LANGUAGE FlexibleContexts #-}
--- {-# LANGUAGE MonoLocalBinds #-}
+-- {-\# LANGUAGE ScopedTypeVariables \#-}
+-- {-\# LANGUAGE FlexibleContexts \#-}
+-- {-\# LANGUAGE MonoLocalBinds \#-}
 -- @
 --
 

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -22,6 +22,7 @@
 -- @
 -- {-# LANGUAGE ScopedTypeVariables #-}
 -- {-# LANGUAGE FlexibleContexts #-}
+-- {-# LANGUAGE MonoLocalBinds #-}
 -- @
 --
 

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -7,10 +7,22 @@
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
 #endif
 
--- | The main entry-point of this library.
+-- | A monadic library for implementing effectful computation in a modular way.
 --
--- This module provides the @Eff@ monad - the base monad for all effectful
+-- This module provides the @Eff@ monad - the base type for all effectful
 -- computation.
+-- The @Member@ typeclass is the main interface for describing the .
+--
+-- Consult the @Control.Eff.QuickStart@ module and the readme for gentle
+-- introductions.
+--
+-- To use extensible effects effectively some language extensions are
+-- necessary/suggested.
+--
+-- @
+-- {-# LANGUAGE ScopedTypeVariables #-}
+-- {-# LANGUAGE FlexibleContexts #-}
+-- @
 --
 
 module Control.Eff

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -2,10 +2,13 @@
 
 module Control.Eff
   ( -- * Effect base-type
-    Internal.Eff
+    -- | The the monad that contains all effects --TODO: comment
+    Internal.run
+  , Internal.Eff
     -- * Effect list
   , OpenUnion.Member
-    -- Rest (not included in documentation)
+  , type(<::)
+    -- Rest (not included in documentation somehow)
   , module Internal
   , module OpenUnion
   ) where

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -1,6 +1,14 @@
-module Control.Eff ( module Internal
-                   , module OpenUnion
-                   ) where
+{-# OPTIONS_GHC -Wno-duplicate-exports #-}
+
+module Control.Eff
+  ( -- * Effect base-type
+    Internal.Eff
+    -- * Effect list
+  , OpenUnion.Member
+    -- Rest (not included in documentation)
+  , module Internal
+  , module OpenUnion
+  ) where
 
 import Control.Eff.Internal as Internal hiding (Lift(..), lift, runLift)
 import Data.OpenUnion as OpenUnion

--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -1,4 +1,11 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+
+#if __GLASGOW_HASKELL__ < 800
+{-# OPTIONS_GHC -fno-warn-duplicate-exports #-}
+#else
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
+#endif
 
 -- | The main entry-point of this library.
 --

--- a/src/Control/Eff/Choose.hs
+++ b/src/Control/Eff/Choose.hs
@@ -18,8 +18,10 @@ module Control.Eff.Choose ( Choose (..)
                           , mplus'
                           ) where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
+      
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Base

--- a/src/Control/Eff/Coroutine.hs
+++ b/src/Control/Eff/Coroutine.hs
@@ -11,6 +11,7 @@ module Control.Eff.Coroutine( Yield (..)
                             ) where
 
 import Control.Eff
+import Control.Eff.Extend
 
 -- ------------------------------------------------------------------------
 -- | Co-routines

--- a/src/Control/Eff/Cut.hs
+++ b/src/Control/Eff/Cut.hs
@@ -41,6 +41,7 @@
 module Control.Eff.Cut where
 
 import Control.Eff
+import Control.Eff.Extend
 import Control.Eff.Exception
 import Control.Eff.Choose
 

--- a/src/Control/Eff/Example.hs
+++ b/src/Control/Eff/Example.hs
@@ -7,6 +7,7 @@
 module Control.Eff.Example where
 
 import Control.Eff
+import Control.Eff.Extend
 import Control.Eff.Exception
 
 import Control.Eff.Reader.Lazy

--- a/src/Control/Eff/Exception.hs
+++ b/src/Control/Eff/Exception.hs
@@ -24,8 +24,9 @@ module Control.Eff.Exception ( Exc (..)
                             , ignoreFail
                             ) where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
 
 import Control.Monad (void)
 import Control.Monad.Base
@@ -54,8 +55,8 @@ throwError :: (Member (Exc e) r) => e -> Eff r a
 throwError e = send (Exc e)
 {-# INLINE throwError #-}
 
--- | Throw an exception in an effectful computation. The type is unit, 
---   which suppresses the ghc-mod warning "A do-notation statement 
+-- | Throw an exception in an effectful computation. The type is unit,
+--   which suppresses the ghc-mod warning "A do-notation statement
 --   discarded a result of type"
 throwError_ :: (Member (Exc e) r) => e -> Eff r ()
 throwError_ = throwError

--- a/src/Control/Eff/Extend.hs
+++ b/src/Control/Eff/Extend.hs
@@ -1,6 +1,8 @@
 -- | This module exports functions, types, and typeclasses necessary for
--- implementing a custom effect and/or effect handler
-module Control.Eff.ImplementYourOwnEffect
+-- implementing a custom effect and/or effect handler.
+--
+
+module Control.Eff.Extend
   ( -- * Open Unions
     OpenUnion.Union
   , inj

--- a/src/Control/Eff/Extend.hs
+++ b/src/Control/Eff/Extend.hs
@@ -3,8 +3,12 @@
 --
 
 module Control.Eff.Extend
-  ( -- * Open Unions
-    OpenUnion.Union
+  ( -- * The effect monad
+    Eff(..)
+  , run
+    -- * Open Unions
+  , OpenUnion.Union
+  , OpenUnion.Member
   , inj
   , prj
   , decomp
@@ -15,6 +19,7 @@ module Control.Eff.Extend
   , handle_relay_s
   , interpose
   , raise
+  , send
   -- * Arrow types and compositions
   , Arr
   , Arrs

--- a/src/Control/Eff/Fresh.hs
+++ b/src/Control/Eff/Fresh.hs
@@ -13,8 +13,9 @@ module Control.Eff.Fresh( Fresh (Fresh)
                         , runFresh'
                         ) where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
 
 import Control.Monad.Base
 import Control.Monad.Trans.Control

--- a/src/Control/Eff/ImplementYourOwnEffect.hs
+++ b/src/Control/Eff/ImplementYourOwnEffect.hs
@@ -1,1 +1,15 @@
-module Control.Eff.ImplementYourOwnEffect where
+-- | This module exports functions, types, and typeclasses necessary for
+-- implementing a custom effect and/or effect handler
+module Control.Eff.ImplementYourOwnEffect
+  ( -- * Open Unions
+    OpenUnion.Union
+  , inj
+  , prj
+  , decomp
+  -- , Member already exported in Control.Eff; users should import both
+  , SetMember
+  , weaken
+  ) where
+
+--import Control.Eff.Internal as Internal hiding (Lift(..), lift, runLift)
+import Data.OpenUnion as OpenUnion

--- a/src/Control/Eff/ImplementYourOwnEffect.hs
+++ b/src/Control/Eff/ImplementYourOwnEffect.hs
@@ -6,10 +6,28 @@ module Control.Eff.ImplementYourOwnEffect
   , inj
   , prj
   , decomp
-  -- , Member already exported in Control.Eff; users should import both
   , SetMember
   , weaken
-  ) where
+  -- * Helper functions that are used for implementing effect-handlers
+  , handle_relay
+  , handle_relay_s
+  , interpose
+  , raise
+  -- * Arrow types and compositions
+  , Arr
+  , Arrs
+  , first
+  , singleK
+  , qApp
+  , (^$)
+  , arr
+  , ident
+  , comp
+  , (^|>)
+  , qComp
+  , qComps
+  )
+where
 
---import Control.Eff.Internal as Internal hiding (Lift(..), lift, runLift)
-import Data.OpenUnion as OpenUnion
+import           Data.OpenUnion                as OpenUnion
+import           Control.Eff.Internal

--- a/src/Control/Eff/ImplementYourOwnEffect.hs
+++ b/src/Control/Eff/ImplementYourOwnEffect.hs
@@ -1,0 +1,1 @@
+module Control.Eff.ImplementYourOwnEffect where

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -22,36 +22,7 @@
 -- Extensible Effects are implemented as typeclass constraints on an Eff[ect] datatype.
 -- A contrived example can be found under "Control.Eff.Example". To run the
 -- effects, consult the tests.
-module Control.Eff.Internal
-  (
-    -- * the Effect type
-    Eff(..)
-  , run
-  , send
-    -- * helper functions that are used for implementing effect-handlers
-  , handle_relay
-  , handle_relay_s
-  , interpose
-  , raise
-    -- * lift
-  , Lift(..)
-  , lift
-  , runLift
-    -- * arrow types and compositions
-    -- | Effectful arrows are are used for raw interaction with the Eff monad
-  , Arr
-  , Arrs
-  , first
-  , singleK
-  , qApp
-  , (^$)
-  , arr
-  , ident
-  , comp
-  , (^|>)
-  , qComp
-  , qComps
-  ) where
+module Control.Eff.Internal where
 
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
@@ -110,7 +81,7 @@ qApp (Arrs q) x = viewlMap (inline tviewl q) ($ x) cons
 qApp :: Arrs r b w -> b -> Eff r w
 qApp q x = case tviewl q of
    TOne k  -> k x
-   k :| t -> binqCompsd' (k x) t
+   k :| t -> bind' (k x) t
  where
    bind' :: Eff r a -> Arrs r a b -> Eff r b
    bind' (Pure y) k     = qApp k y

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -28,7 +28,7 @@ module Control.Eff.Internal
     Eff(..)
   , run
   , send
-    -- * helper functions that are use
+    -- * helper functions that are used for implementing effect-handlers
   , handle_relay
   , handle_relay_s
   , interpose
@@ -37,7 +37,8 @@ module Control.Eff.Internal
   , Lift(..)
   , lift
   , runLift
-    -- * arrow types
+    -- * arrow types and compositions
+    -- | Effectful arrows are are used for raw interaction with the Eff monad
   , Arr
   , Arrs
   , first

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -22,8 +22,35 @@
 -- Extensible Effects are implemented as typeclass constraints on an Eff[ect] datatype.
 -- A contrived example can be found under "Control.Eff.Example". To run the
 -- effects, consult the tests.
-module Control.Eff.Internal ( module Control.Eff.Internal
-                            ) where
+module Control.Eff.Internal
+  (
+    -- * the Effect type
+    Eff(..)
+  , run
+  , send
+    -- * helper functions that are use
+  , handle_relay
+  , handle_relay_s
+  , interpose
+  , raise
+    -- * lift
+  , Lift(..)
+  , lift
+  , runLift
+    -- * arrow types
+  , Arr
+  , Arrs
+  , first
+  , singleK
+  , qApp
+  , (^$)
+  , arr
+  , ident
+  , comp
+  , (^|>)
+  , qComp
+  , qComps
+  ) where
 
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
@@ -82,7 +109,7 @@ qApp (Arrs q) x = viewlMap (inline tviewl q) ($ x) cons
 qApp :: Arrs r b w -> b -> Eff r w
 qApp q x = case tviewl q of
    TOne k  -> k x
-   k :| t -> bind' (k x) t
+   k :| t -> binqCompsd' (k x) t
  where
    bind' :: Eff r a -> Arrs r a b -> Eff r b
    bind' (Pure y) k     = qApp k y
@@ -189,10 +216,10 @@ send t = E (inj t) (singleK Val)
 
 
 -- ------------------------------------------------------------------------
--- | The initial case, no effects. Get the result from a pure computation.
+-- | Get the result from a pure (i.e. no effects) computation.
 --
 -- The type of run ensures that all effects must be handled:
--- only pure computations may be run.
+-- only pure computations can be run.
 run :: Eff '[] w -> w
 run (Val x) = x
 -- | the other case is unreachable since Union [] a cannot be

--- a/src/Control/Eff/NdetEff.hs
+++ b/src/Control/Eff/NdetEff.hs
@@ -15,8 +15,9 @@
 -- | Another implementation of nondeterministic choice effect
 module Control.Eff.NdetEff where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
 
 import Control.Applicative
 import Control.Monad

--- a/src/Control/Eff/Operational.hs
+++ b/src/Control/Eff/Operational.hs
@@ -19,6 +19,7 @@ module Control.Eff.Operational ( Program (..)
                                ) where
 
 import Control.Eff
+import Control.Eff.Extend
 
 -- | Lift values to an effect.
 -- You can think this is a generalization of @Lift@.

--- a/src/Control/Eff/QuickStart.hs
+++ b/src/Control/Eff/QuickStart.hs
@@ -12,9 +12,14 @@
 -- be used to construct much more complicated programs by composing the little
 -- pieces shown here.
 --
--- This module imports and reexports modules from this library:
+-- This module imports and reexports modules from this library and requires
+-- some language extensions:
 --
 -- @
+-- {-\# LANGUAGE ScopedTypeVariables \#-}
+-- {-\# LANGUAGE FlexibleContexts \#-}
+-- {-\# LANGUAGE MonoLocalBinds \#-}
+--
 -- import Control.Eff
 -- import Control.Eff.Reader.Lazy
 -- import Control.Eff.Writer.Lazy
@@ -22,13 +27,8 @@
 -- import Control.Eff.Exception
 -- @
 --
--- also, some language extensions are required
---
--- @
--- {-# LANGUAGE ScopedTypeVariables #-}
--- {-# LANGUAGE FlexibleContexts #-}
--- {-# LANGUAGE MonoLocalBinds #-}
--- @
+-- If you want to see what each extension is good for, you can disable it and
+-- see what GHC will complain about.
 --
 module Control.Eff.QuickStart
   ( -- * Examples

--- a/src/Control/Eff/QuickStart.hs
+++ b/src/Control/Eff/QuickStart.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
 
 -- | This module contains several tiny examples of how to use effects.
 -- For technical details, see the documentation in the effect-modules.
@@ -26,6 +27,7 @@
 -- @
 -- {-# LANGUAGE ScopedTypeVariables #-}
 -- {-# LANGUAGE FlexibleContexts #-}
+-- {-# LANGUAGE MonoLocalBinds #-}
 -- @
 --
 module Control.Eff.QuickStart

--- a/src/Control/Eff/QuickStart.hs
+++ b/src/Control/Eff/QuickStart.hs
@@ -21,6 +21,13 @@
 -- import Control.Eff.Exception
 -- @
 --
+-- also, some language extensions are required
+--
+-- @
+-- {-# LANGUAGE ScopedTypeVariables #-}
+-- {-# LANGUAGE FlexibleContexts #-}
+-- @
+--
 module Control.Eff.QuickStart
   ( -- * Examples
     module Control.Eff.QuickStart

--- a/src/Control/Eff/Reader/Lazy.hs
+++ b/src/Control/Eff/Reader/Lazy.hs
@@ -15,8 +15,9 @@ module Control.Eff.Reader.Lazy ( Reader (..)
                               , runReader
                               ) where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
 
 import Control.Monad.Base
 import Control.Monad.Trans.Control

--- a/src/Control/Eff/Reader/Strict.hs
+++ b/src/Control/Eff/Reader/Strict.hs
@@ -16,8 +16,9 @@ module Control.Eff.Reader.Strict ( Reader (..)
                               , runReader
                               ) where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
 
 import Control.Monad.Base
 import Control.Monad.Trans.Control

--- a/src/Control/Eff/State/Lazy.hs
+++ b/src/Control/Eff/State/Lazy.hs
@@ -11,10 +11,12 @@
 -- | Lazy state effect
 module Control.Eff.State.Lazy where
 
-import Control.Eff.Internal
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
+
 import Control.Eff.Writer.Lazy
 import Control.Eff.Reader.Lazy
-import Data.OpenUnion
 
 import Control.Monad.Base
 import Control.Monad.Trans.Control

--- a/src/Control/Eff/State/OnDemand.hs
+++ b/src/Control/Eff/State/OnDemand.hs
@@ -11,10 +11,12 @@
 -- | Lazy state effect
 module Control.Eff.State.OnDemand where
 
-import Control.Eff.Internal
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
+
 import Control.Eff.Writer.Lazy
 import Control.Eff.Reader.Lazy
-import Data.OpenUnion
 
 import Control.Monad.Base
 import Control.Monad.Trans.Control

--- a/src/Control/Eff/State/Strict.hs
+++ b/src/Control/Eff/State/Strict.hs
@@ -12,10 +12,12 @@
 -- | Strict state effect
 module Control.Eff.State.Strict where
 
-import Control.Eff.Internal
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
+
 import Control.Eff.Writer.Strict
 import Control.Eff.Reader.Strict
-import Data.OpenUnion
 
 import Control.Monad.Base
 import Control.Monad.Trans.Control

--- a/src/Control/Eff/Trace.hs
+++ b/src/Control/Eff/Trace.hs
@@ -10,6 +10,7 @@ module Control.Eff.Trace( Trace (..)
                         ) where
 
 import Control.Eff
+import Control.Eff.Extend
 
 -- | Trace effect for debugging
 data Trace v where

--- a/src/Control/Eff/Writer/Lazy.hs
+++ b/src/Control/Eff/Writer/Lazy.hs
@@ -24,8 +24,9 @@ module Control.Eff.Writer.Lazy ( Writer(..)
                                , execMonoidWriter
                                ) where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
 
 import Control.Applicative ((<|>))
 

--- a/src/Control/Eff/Writer/Strict.hs
+++ b/src/Control/Eff/Writer/Strict.hs
@@ -25,8 +25,9 @@ module Control.Eff.Writer.Strict ( Writer(..)
                                , execMonoidWriter
                                ) where
 
-import Control.Eff.Internal
-import Data.OpenUnion
+import Control.Eff
+import Control.Eff.Extend
+import Control.Eff.Lift
 
 import Control.Applicative ((<|>))
 

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -94,6 +94,11 @@ prj' n (Union n' x) | n == n'   = Just (unsafeCoerce x)
 
 newtype P t r = P{unP :: Int}
 
+-- | Typeclass that asserts that effect @t@ is contained inside the effect-list
+-- @r@.
+--
+-- The @FindElem@ typeclass is necessary for implementation reasons and is not
+-- required for using the effect list.
 class (FindElem t r) => Member (t :: * -> *) r where
   inj :: t v -> Union r v
   prj :: Union r v -> Maybe (t v)

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ extra-deps: []
 flags:
   extensible-effects:
     force-openunion-51: false
-    lib-werror: false
+    lib-werror: true
 
 extra-package-dbs: []
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,10 +8,9 @@ extra-deps: []
 flags:
   extensible-effects:
     force-openunion-51: false
-    lib-werror: true
+    lib-werror: false
 
 extra-package-dbs: []
 
 nix:
   packages: []
-

--- a/stack/stack-8.4.2.yaml
+++ b/stack/stack-8.4.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-04-21
+resolver: nightly-2018-05-30
 
 packages:
 - '..'


### PR DESCRIPTION
Continuing with #99.

Currently, there seems to be a problem with the [Control.Eff](https://hackage.haskell.org/package/extensible-effects-2.6.2.0/docs/Control-Eff.html) documentation on hackage: It is empty. Before that, the documentation was not clear at all (see [Hackage of Version 2.4](https://hackage.haskell.org/package/extensible-effects-2.4.0.0/docs/Control-Eff.html)): It contained types that are necessary for implementing effects as well as types for using effects. I am a strong proponent of only displaying the types needed for using effects in the `Control.Eff` module - making it more beginner friendly.

This pull request is a step towars addressing this issue: making a curated export-list of the `Control.Eff` module in order to have a helpful documentation page. Also, it only contains the minimum number of entries to use this library and contains no helper functions like `handle_relay`. The `ImplementYourOwnEffect` module is meant for people that are implementing a custom effect. That module should be imported by them. Note that the internal modules are still re-exported without haddock-documentaiton. Personally, I would like to phase that out and require library-implementors to import the implementor's module, but am willing to keep that for backwards compability.

To see the changes locally, run `stack haddock` and inspect the output. It should present you with a number of generated `index.html`s. One of those is the newly generated haddock for this branch.

Any comments / suggestions are appreciated