### PR TITLE
Improve haddock documentation on important types and functions

### DIFF
--- a/src/Control/Eff.hs
+++ b/src/Control/Eff.hs
@@ -21,7 +21,7 @@
 --
 
 module Control.Eff
-  ( -- * Effect base-type
+  ( -- * Effect type
     Internal.run
   , Internal.Eff
     -- * Effect list

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -111,10 +111,15 @@ comp (Arrs f) (Arrs g) = Arrs (f >< g)
 
 -- | The monad that all effects in this library are based on.
 --
--- An effectful computation is a value of type `Eff r a` where `r` is a
--- type-level list of effects that can be requested inside an effectful
--- computation and `a` is the computation's result.
+-- An effectful computation is a value of type `Eff r a`.
+-- In this signature, `r` is a type-level list of effects that can be requested
+-- and need to be handled inside an effectful computation.
+--`a` is the computation's result similar to other monads.
 --
+-- A computation's result can be retrieved via the 'run' function.
+-- However, all effects used in the computation need to be handled by the use
+-- of the effects' @run*@ functions before unwrapping the final result.
+-- For additional details, see the documentation of the effects you are using.
 data Eff r a = Val a
              | forall b. E (Union r b) (Arrs r b a)
 
@@ -179,14 +184,13 @@ send t = E (inj t) (singleK Val)
 
 
 -- ------------------------------------------------------------------------
--- | Get the result from a pure computation (i.e. no unhandled effects) .
+-- | Get the result from a pure computation
 --
--- The type of run ensures that all effects must be handled:
--- only pure computations can be run.
+-- A pure computation has type @Eff '[] a@. The empty effect-list indicates that
+-- no furhter effect needs to be handled.
 run :: Eff '[] w -> w
 run (Val x) = x
--- | the other case is unreachable since Union [] a cannot be
--- constructed.
+-- | the other case is unreachable since @Union []@ has no nonbottom values
 -- Therefore, run is a total function if its argument terminates.
 run (E _ _) = error "extensible-effects: the impossible happened!"
 

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -190,9 +190,13 @@ send t = E (inj t) (singleK Val)
 -- no furhter effect needs to be handled.
 run :: Eff '[] w -> w
 run (Val x) = x
--- | the other case is unreachable since @Union []@ has no nonbottom values
--- Therefore, run is a total function if its argument terminates.
-run (E _ _) = error "extensible-effects: the impossible happened!"
+-- | @Union []@ has no nonbottom values.
+-- Due to laziness it is possible to get into this branch but its union argument
+-- cannot terminate.
+-- To extract the true error, the evaluation of union is forced.
+-- 'run' is a total function if its argument is different from bottom.
+run (E union _) =
+  union `seq` error "extensible-effects: the impossible happened!"
 
 -- | A convenient pattern: given a request (open union), either
 -- handle it or relay it.

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -112,8 +112,8 @@ comp (Arrs f) (Arrs g) = Arrs (f >< g)
 -- | The monad that all effects in this library are based on.
 --
 -- An effectful computation is a value of type `Eff r a`.
--- In this signature, `r` is a type-level list of effects that can be requested
--- and need to be handled inside an effectful computation.
+-- In this signature, `r` is a type-level list of effects that are being
+-- requested and need to be handled inside an effectful computation.
 --`a` is the computation's result similar to other monads.
 --
 -- A computation's result can be retrieved via the 'run' function.
@@ -187,7 +187,7 @@ send t = E (inj t) (singleK Val)
 -- | Get the result from a pure computation
 --
 -- A pure computation has type @Eff '[] a@. The empty effect-list indicates that
--- no furhter effect needs to be handled.
+-- no further effects need to be handled.
 run :: Eff '[] w -> w
 run (Val x) = x
 -- | @Union []@ has no nonbottom values.

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -115,12 +115,6 @@ comp (Arrs f) (Arrs g) = Arrs (f >< g)
 -- type-level list of effects that can be requested inside an effectful
 -- computation and `a` is the computation's result.
 --
--- Effects occuring inside the effect-list @r@ can be handled via the
--- effect's `run*` functions.
---
--- To get started, have a look at the examples in the
--- 'Control.Eff.QuickStart.quickstart' module.
---
 data Eff r a = Val a
              | forall b. E (Union r b) (Arrs r b a)
 

--- a/src/Control/Eff/Internal.hs
+++ b/src/Control/Eff/Internal.hs
@@ -109,19 +109,20 @@ comp (Arrs f) (Arrs g) = Arrs (f >< g)
 (^|>) :: Arrs r a b -> Arr r b c -> Arrs r a c
 (Arrs f) ^|> g = Arrs (f |> g)
 
--- | The monad that all effectful computation in this library bases on.
+-- | The monad that all effects in this library are based on.
 --
--- The type `Eff r a` has 2 argumens where `r` is a type-level list of effects
--- that can occur inside an effectful computation and `a` is the computation's
--- result.
+-- An effectful computation is a value of type `Eff r a` where `r` is a
+-- type-level list of effects that can be requested inside an effectful
+-- computation and `a` is the computation's result.
 --
--- This monad is used via the  functions provided by  concrete effect-types
--- implemented in this or another library.
--- Have a look at the examples in the 'Control.Eff.QuickStart.quickstart'
--- module.
+-- Effects occuring inside the effect-list @r@ can be handled via the
+-- effect's `run*` functions.
+--
+-- To get started, have a look at the examples in the
+-- 'Control.Eff.QuickStart.quickstart' module.
 --
 data Eff r a = Val a
-             | forall b. E  (Union r b) (Arrs r b a)
+             | forall b. E (Union r b) (Arrs r b a)
 
 -- | Compose effectful arrows (and possibly change the effect!)
 {-# INLINE qComp #-}
@@ -253,7 +254,8 @@ raise = loop
 -- | Lifting: emulating monad transformers
 newtype Lift m a = Lift (m a)
 
--- | lift a operation of type `m a` into the `Eff` monad.
+-- | embed an operation of type `m a` into the `Eff` monad when @Lift m@ is in
+-- a part of the effect-list.
 --
 -- By using SetMember, it is possible to assert that the lifted type occurs
 -- only once in the effect list

--- a/src/Control/Eff/QuickStart.hs
+++ b/src/Control/Eff/QuickStart.hs
@@ -45,6 +45,13 @@ import           Control.Eff.State.Lazy
 import           Control.Eff.Exception
 import           Control.Monad                            ( when )
 
+-- | a function that runs through some examples
+quickstart :: IO ()
+quickstart = do
+    putStrLn "a few examples"
+    putStrLn ""
+    putStrLn "work in progress"
+    putStrLn ""
 
 -- | an effectful function that can throw an error
 --

--- a/src/Control/Eff/QuickStart.hs
+++ b/src/Control/Eff/QuickStart.hs
@@ -45,14 +45,6 @@ import           Control.Eff.State.Lazy
 import           Control.Eff.Exception
 import           Control.Monad                            ( when )
 
--- | a function that runs through some examples
-quickstart :: IO ()
-quickstart = do
-    putStrLn "a few examples"
-    putStrLn ""
-    putStrLn "work in progress"
-    putStrLn ""
-
 -- | an effectful function that can throw an error
 --
 -- @

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -97,7 +97,7 @@ newtype P t r = P{unP :: Int}
 -- | Typeclass that asserts that effect @t@ is contained inside the effect-list
 -- @r@.
 --
--- The @FindElem@ typeclass is a implementation detail and not required for
+-- The @FindElem@ typeclass is an implementation detail and not required for
 -- using the effect list or implementing custom effects.
 class (FindElem t r) => Member (t :: * -> *) r where
   inj :: t v -> Union r v

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -97,8 +97,8 @@ newtype P t r = P{unP :: Int}
 -- | Typeclass that asserts that effect @t@ is contained inside the effect-list
 -- @r@.
 --
--- The @FindElem@ typeclass is necessary for implementation reasons and is not
--- required for using the effect list.
+-- The @FindElem@ typeclass is a implementation detail and not required for
+-- using the effect list or implementing custom effects.
 class (FindElem t r) => Member (t :: * -> *) r where
   inj :: t v -> Union r v
   prj :: Union r v -> Maybe (t v)
@@ -144,17 +144,13 @@ instance {-# INCOHERENT #-}  (FindElem t r) => Member t r where
   prj = prj' (unP $ (elemNo :: P t r))
 #endif
 
--- | A useful operator for reducing boilerplate.
+-- | A useful operator for reducing boilerplate in signatures.
+--
+-- The following lines are equivalent.
 --
 -- @
--- f :: [Reader Int, Writer String] <:: r
---   => a -> Eff r b
--- @
--- is equal to
---
--- @
--- f :: (Member (Reader Int) r, Member (Writer String) r)
---   => a -> Eff r b
+-- (Member (Exc e) r, Member (State s) r) => ...
+-- [ Exc e, State s ] <:: r => ...
 -- @
 type family (<::) (ms :: [* -> *]) r where
   (<::) '[] r = (() :: Constraint)


### PR DESCRIPTION
This is a small PR that heavily increases the readability of the most important entry points of the library.

The documentation as it is currently is clearly written by an academic, which was fine at the time but in an effort to make this library usable for a boarder audience the amount of knowledge required to understand the basic concepts should be lowered.

I acknowledge that my proposed alternatives are not perfect and I am open for suggestions.